### PR TITLE
Updated CFP draft

### DIFF
--- a/content/cfp/banner.md
+++ b/content/cfp/banner.md
@@ -31,10 +31,10 @@ advanced:
 Under construction -- Will be completed soon. The text below is just a placeholder.
 {{% /callout %}}
 
-The 2025 ACM Conference on Reproducibility and Replicability (ACM REP '25) aims to bring together experts and practitioners engaged in the advancement and conduct of reproducible science in computing disciplines. The first-of-its-kind conference will serve as a premier forum for the exchange and presentation of the concepts, tools, techniques, practice and state-of-art in reproducible science. The conference committee invites original research contributions and practical system designs, implementations and evaluations on several topics relating to reproducibility and replicability. The ACM REP program will consist of peer-reviewed articles, invited talks, panels, and posters, and demonstrations. 
+The 3rd ACM Conference on Reproducibility and Replicability (ACM REP '25) aims to bring together experts and practitioners engaged in the advancement and conduct of reproducible science in computing disciplines. The conference will serve as a premier forum for the exchange and presentation of the concepts, tools, techniques, practice and state-of-art in reproducible science. The conference committee invites original research contributions and practical system designs, implementations, and evaluations on several topics relating to reproducibility and replicability. The ACM REP program will consist of peer-reviewed articles, invited talks, panels, posters, and demonstrations. 
 
 {{< cta cta_text="Submit -->" cta_link="https://easychair.org/my/conference?conf=acmrep2025" cta_new_tab="false" >}}
 
-The ACM REP conference series is associated with the [ACM Emerging Interest Group for Reproducibility and Replicability](https://reproducibility.acm.org/) (see [here](https://acm-rep.github.io/history) for ACM REP's history). All accepted papers will be published by ACM - International Conference Proceedings Series (ICPS) and will be available in the ACM Digital Library.
+The ACM REP conference series is associated with the [ACM Emerging Interest Group for Reproducibility and Replicability](https://reproducibility.acm.org/). (See ACM REP's [history](https://acm-rep.github.io/history).) All accepted papers will be published in the ACM - International Conference Proceedings Series (ICPS) and will be available in the ACM Digital Library.
 
 **Table of Contents:** [Topics of Interest](#topics) | [Submission Guidelines](#submissions) | [**Important Dates**](#deadlines) | [Program Committee](#pc)

--- a/content/cfp/submissions.md
+++ b/content/cfp/submissions.md
@@ -6,27 +6,27 @@ title: "Submission Guidelines"
 subtitle: ""
 active: true
 ---
-We solicit papers describing original work relevant to reproducibility and independent verification of scientific results. And not published or under review elsewhere. ACM REP is a single-blind reviewed conference. Therefore, authors must include their names and affiliations on the first page. ACM REP submissions can be either research papers, surveys, vision, and experience papers. Papers will be evaluated according to their significance, originality, technical content, style, clarity, relevance, and likelihood of generating discussion. Authors should note that changes to the author list after the submission deadline are not allowed without permission from the PC Chairs. At least one author of each accepted paper is required to register for, attend, and present the work at the conference. 
+We solicit papers describing original work relevant to reproducibility and independent verification of scientific results. The submission must not be published or under review elsewhere. ACM REP is a double-blind reviewed conference. ACM REP submissions can be research, survey, vision, or experience papers. Submissions will be evaluated according to their significance, originality, technical content, style, clarity, relevance, and likelihood of generating discussion. Authors should note that changes to the author list after the submission deadline are not allowed without permission from the PC Chairs. At least one author of each accepted paper is required to register for, attend, and present the work at the conference. 
 
 {{% callout note %}}
-Remote attendance and presentations are welcome even though in-person attendance and presentations are highly encouraged.
+In-person attendance and presentation is highly encouraged, but remote participation will also be supported.
 {{% /callout %}}
 
 ### Research Papers (Long and Short)
 
-We solicit both full length papers (10 pages) and short papers (4 pages). The former tend to be descriptions of complete technical work, while the latter tend to be descriptions of interesting, innovative ideas, which nevertheless require more work to mature. The program committee may decide to accept some full papers as short papers. Full papers will be given a presentation slot in the conference, while short papers will be presented in the form of posters. All papers regardless of size, will be given an entry in the conference proceedings. The requested page limit is without references. Authors may optionally include reproducibility information that allows for automated validation of experimental results (see artifact evaluation criteria) Accepted submissions passing automated validation will earn the ACM Reproducibility badges in accordance with the artifact review and validation policy.
+We solicit both full length papers (10 pages) and short papers (4 pages). The former tend to be descriptions of complete technical work, while the latter tend to be descriptions of interesting, innovative ideas, which nevertheless require more effort to mature. The program committee may decide to accept some full papers as short papers. Full papers will be given a presentation slot in the conference, while short papers will be presented in the form of posters. All papers, regardless of size, will be given an entry in the conference proceedings. The page limit is without references and/or appendices. Authors may optionally include reproducibility information that allows for automated validation of experimental results. (See the artifact evaluation criteria below.) Accepted submissions that pass automated validation will earn ACM Reproducibility badges in accordance with the artifact review and validation policy.
 
 ### Artifact Evaluation Criteria
 
-The conference will also be soliciting code/data artifacts. For submitted papers, these artifacts will be optional supplemental material and solicited based on the PC criteria. The artifacts will be mandatory for accepted full papers with experimental results. The artifacts will be reviewed by an Artifact Evaluation committee, and those that pass will be awarded [Reproducibility Badges](https://www.acm.org/publications/policies/artifact-review-and-badging-current) per ACM policy. 
+The conference will also be soliciting code/data artifacts. For submitted papers, these artifacts will be optional supplemental material and solicited based on the program committee's criteria. The artifacts will be mandatory for accepted full papers with experimental results. The artifacts will be reviewed by an Artifact Evaluation committee, and those that pass will be awarded [Reproducibility Badges](https://www.acm.org/publications/policies/artifact-review-and-badging-current) per ACM policy.
 
 ### Formatting 
 
-Papers must be submitted in PDF format according to the ACM template published in the ACM guidelines, selecting the generic “sigconf” sample. The PDF files must have all non-standard fonts embedded. Papers must be self-contained and in English. If submitting a short paper, authors must indicate "SHORT:" at the beginning of the title. The review process is single-blind. 
+Papers must be submitted in PDF format according to the ACM template published in the ACM guidelines, selecting the generic “sigconf” sample. The PDF files must have all non-standard fonts embedded. Papers must be self-contained and in English. If submitting a short paper, authors must indicate “SHORT:” at the beginning of the title. The review process is double-blind. 
 
 ### Submission Site
 
-The conference submission site is https://acm-rep25.hotcrp.com
+The conference submission site is: [https://easychair.org/conferences?conf=acmrep2025](https://easychair.org/conferences?conf=acmrep2025)
 
 {{< cta cta_text="Submit -->" cta_link="https://easychair.org/my/conference?conf=acmrep2025" cta_new_tab="false" >}}
 

--- a/content/cfp/topics.md
+++ b/content/cfp/topics.md
@@ -7,9 +7,9 @@ subtitle: ""
 active: true
 ---
 
-ACM REP '25 invites submissions in several categories as described below with focus on computing disciplines within computer science and across scientific computing disciplines of biology, chemistry, physics, astronomy, genomics, geosciences, etc. The conference encourages submissions in which experimental results are reproducible in of themselves and, if not, then sufficiently documents the reproducibility experience. 
+ACM REP '25 welcomes submissions across computing disciplines, spanning both traditional computer science and interdisciplinary scientific computing applications in biology, chemistry, physics, astronomy, genomics, geosciences, etc. The conference particularly values submissions that demonstrate reproducible experimental results. Where full reproduction is not achieved, detailed documentation of the reproducibility experience is equally valuable.
 
-Topics of interest include, but are not limited to, the following as they relate to various aspects of reproducibility and replicability. 
+The conference addresses various aspects of reproducibility and replicability, including but not limited to the following topics: 
 
 ### Reproducibility Concepts 
 - Experiment dependency management.
@@ -32,7 +32,8 @@ Topics of interest include, but are not limited to, the following as they relate
 - Usability and adaptability of reproducibility frameworks into already-established domain-specific tools.
 - Frameworks for sociological constructs to incentivize paradigm shifts.
 - Policies around publication of articles/software.
-- Experiences within computational science communities
+- Experiences within computational science communities.
+- Experience comparing published systems in a domain.
 
 ### Broader Reproducibility
 - Cost-benefit analysis frameworks for reproducibility.


### PR DESCRIPTION
- Various edits to wording.
- Under 'Reproducibility Experiences', an additional bullet:
        "Experience comparing published systems in a domain."
- The 'Submission Guidelines' and 'Formatting' were updated to state that conference review will be double-blind.
- In addition to references, appendices are also explicitly excluded from page limits.